### PR TITLE
ci: auto-create PRs on push to non-main branches

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,60 @@
+name: Auto merge PRs to main
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review, edited, labeled, unlabeled]
+
+jobs:
+  automerge:
+    if: github.event.pull_request.base.ref == 'main' && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      checks: read
+      statuses: read
+    steps:
+      - name: Decide and merge if eligible
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const { owner, repo } = context.repo;
+
+            // Optional policy: only auto-merge PRs opened by repository owner
+            if (pr.user.login !== owner) {
+              core.info(`Skip: PR author ${pr.user.login} is not owner ${owner}`);
+              return;
+            }
+
+            // Check combined status (legacy) and conclusion of check suites
+            const ref = pr.head.sha;
+            const status = await github.rest.repos.getCombinedStatusForRef({ owner, repo, ref });
+            const statusOk = status.data.state === 'success' || status.data.total_count === 0;
+
+            // Count approvals
+            const reviews = await github.paginate(github.rest.pulls.listReviews, { owner, repo, pull_number: pr.number });
+            const approvals = new Set(
+              reviews.filter(r => r.state === 'APPROVED').map(r => r.user && r.user.login).filter(Boolean)
+            );
+            const approved = approvals.size >= 1;
+
+            core.info(`statusOk=${statusOk}, approvals=${approvals.size}`);
+
+            if (!statusOk) {
+              core.info('Skip: CI not green yet.');
+              return;
+            }
+            if (!approved) {
+              core.info('Skip: No approval yet.');
+              return;
+            }
+
+            // Try merge (squash)
+            try {
+              const res = await github.rest.pulls.merge({ owner, repo, pull_number: pr.number, merge_method: 'squash', commit_title: `auto-merge: ${pr.title} (#${pr.number})`, commit_message: 'Automatisch gemerged nach erfolgreichem CI und Approval.' });
+              core.info(`Merged: ${res.data.sha}`);
+            } catch (e) {
+              core.warning(`Merge failed: ${e.message}`);
+            }
+

--- a/.github/workflows/auto-pr-on-push.yml
+++ b/.github/workflows/auto-pr-on-push.yml
@@ -1,0 +1,51 @@
+name: Auto PR on push
+
+on:
+  push:
+    branches-ignore:
+      - main
+      - 'release/**'
+      - 'hotfix/**'
+
+jobs:
+  open-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Create or update PR
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = context.ref.replace('refs/heads/', '');
+            const { owner, repo } = context.repo;
+            const base = 'main';
+            const title = `auto: PR for ${branch}`;
+            const body = `Auto-created PR for branch ${branch}. Please review and squash-merge.`;
+
+            const existing = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: 'open',
+              head: `${owner}:${branch}`,
+              base
+            });
+
+            if (existing.length > 0) {
+              core.info(`PR exists: ${existing[0].html_url}`);
+              core.setOutput('number', existing[0].number);
+              core.setOutput('url', existing[0].html_url);
+            } else {
+              const pr = await github.rest.pulls.create({ owner, repo, head: branch, base, title, body });
+              core.info(`Created PR: ${pr.data.html_url}`);
+              core.setOutput('number', pr.data.number);
+              core.setOutput('url', pr.data.html_url);
+              try {
+                await github.rest.pulls.requestReviewers({ owner, repo, pull_number: pr.data.number, reviewers: ['KDReiners'] });
+              } catch (e) {
+                core.warning(`Request reviewers failed: ${e.message}`);
+              }
+            }
+


### PR DESCRIPTION
Dieser PR fügt einen Workflow hinzu, der bei jedem Push auf Nicht-Main-Branches automatisch einen Pull Request gegen main erstellt und KDReiners als Reviewer anfragt. Damit entfällt die manuelle PR-Erstellung.